### PR TITLE
Add preprocessing utilities

### DIFF
--- a/src/preprocess/__init__.py
+++ b/src/preprocess/__init__.py
@@ -1,0 +1,10 @@
+from .disassemble import disassemble_binary
+from .graphify import parse_asm_to_graph, graphify
+from .pipeline import binary_to_graph
+
+__all__ = [
+    "disassemble_binary",
+    "parse_asm_to_graph",
+    "graphify",
+    "binary_to_graph",
+]

--- a/src/preprocess/disassemble.py
+++ b/src/preprocess/disassemble.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+__all__ = ["disassemble_binary"]
+
+
+def disassemble_binary(bin_path: str | Path, out_dir: str | Path) -> Path:
+    """Disassemble a binary using ``objdump -d``.
+
+    Parameters
+    ----------
+    bin_path: str | Path
+        Path to the binary file.
+    out_dir: str | Path
+        Directory where the ``.asm`` file will be stored.
+
+    Returns
+    -------
+    Path
+        Path to the generated assembly file.
+    """
+    bin_path = Path(bin_path)
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    asm_path = out_dir / f"{bin_path.stem}.asm"
+
+    with open(asm_path, "w", encoding="utf-8") as f:
+        subprocess.run(["objdump", "-d", str(bin_path)], check=True, stdout=f)
+
+    return asm_path

--- a/src/preprocess/graphify.py
+++ b/src/preprocess/graphify.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+import torch
+from torch_geometric.data import Data
+
+__all__ = ["parse_asm_to_graph", "graphify"]
+
+_INSTR_RE = re.compile(r"^\s*([0-9a-fA-F]+):\s+(.*)$")
+
+
+def parse_asm_to_graph(path: str | Path) -> Data:
+    """Parse an ``objdump`` assembly listing into a simple control-flow graph."""
+    path = Path(path)
+    lines = path.read_text().splitlines()
+
+    nodes: List[str] = []
+    parsed: List[Tuple[str, str]] = []
+    addr_to_idx: dict[str, int] = {}
+
+    for line in lines:
+        m = _INSTR_RE.match(line)
+        if not m:
+            continue
+        addr, instr = m.groups()
+        instr = instr.split("#")[0].strip()
+        addr_to_idx[addr] = len(nodes)
+        nodes.append(instr)
+        parsed.append((addr, instr))
+
+    edges: List[Tuple[int, int]] = []
+    for i, (addr, instr) in enumerate(parsed):
+        if i + 1 < len(parsed):
+            edges.append((i, i + 1))
+
+        parts = instr.split()
+        if parts and parts[0].startswith("j"):
+            target = parts[-1].strip("<>")
+            if target in addr_to_idx:
+                edges.append((i, addr_to_idx[target]))
+
+    x = torch.tensor([[hash(n) % 1000] for n in nodes], dtype=torch.float)
+    edge_index = (
+        torch.tensor(edges, dtype=torch.long).t().contiguous()
+        if edges
+        else torch.empty((2, 0), dtype=torch.long)
+    )
+    return Data(x=x, edge_index=edge_index)
+
+
+def graphify(asm_path: str | Path, out_path: str | Path) -> Path:
+    """Parse ``asm_path`` and save it as a ``torch_geometric`` graph list."""
+    graph = parse_asm_to_graph(asm_path)
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save([graph], out_path)
+    return out_path

--- a/src/preprocess/pipeline.py
+++ b/src/preprocess/pipeline.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .disassemble import disassemble_binary
+from .graphify import graphify
+
+__all__ = ["binary_to_graph"]
+
+
+def binary_to_graph(bin_path: str | Path, interim_dir: str | Path, processed_dir: str | Path) -> Path:
+    """Run disassembly and graph conversion for a binary.
+
+    Parameters
+    ----------
+    bin_path: str | Path
+        Path to the input binary.
+    interim_dir: str | Path
+        Directory to store intermediate ``.asm`` files.
+    processed_dir: str | Path
+        Directory to store output ``.pt`` graph files.
+    """
+    bin_path = Path(bin_path)
+    interim_dir = Path(interim_dir)
+    processed_dir = Path(processed_dir)
+
+    asm_path = disassemble_binary(bin_path, interim_dir)
+    graph_path = processed_dir / f"{bin_path.stem}.pt"
+    graphify(asm_path, graph_path)
+    return graph_path


### PR DESCRIPTION
## Summary
- add `preprocess` package to convert binaries to assembly and graphs
- implement `disassemble_binary` using `objdump`
- implement `parse_asm_to_graph` and `graphify` for cfg generation
- include a helper to run both steps in `binary_to_graph`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68403d425690832ebcb5ff1910149770