### PR TITLE
Improve graphify CIL parsing

### DIFF
--- a/src/preprocess/graphify.py
+++ b/src/preprocess/graphify.py
@@ -26,7 +26,7 @@ def parse_asm_to_graph(path: str | Path) -> Data:
         if not m:
             continue
         addr, instr = m.groups()
-        instr = instr.split("#")[0].strip()
+        instr = re.split(r"#|//", instr, 1)[0].strip()
         addr_to_idx[addr] = len(nodes)
         nodes.append(instr)
         parsed.append((addr, instr))
@@ -37,12 +37,58 @@ def parse_asm_to_graph(path: str | Path) -> Data:
             edges.append((i, i + 1))
 
         parts = instr.split()
-        if parts and parts[0].startswith("j"):
-            target = parts[-1].strip("<>")
-            if target in addr_to_idx:
-                edges.append((i, addr_to_idx[target]))
+        if not parts:
+            continue
+        op = parts[0].lower()
+        operands = parts[1:]
 
-    x = torch.tensor([[hash(n) % 1000] for n in nodes], dtype=torch.float)
+        targets: List[str] = []
+        if op.startswith("br") or op in {"leave"}:
+            if operands:
+                if op == "switch":
+                    ops = "".join(operands).strip("()")
+                    targets.extend(t.strip() for t in ops.split(","))
+                else:
+                    targets.append(operands[-1])
+        elif (
+            op.startswith("beq")
+            or op.startswith("bge")
+            or op.startswith("bgt")
+            or op.startswith("ble")
+            or op.startswith("blt")
+            or op.startswith("bne")
+            or op in {"brtrue", "brfalse"}
+        ):
+            if operands:
+                targets.append(operands[-1])
+        elif op.startswith("call"):
+            if operands:
+                targets.append(operands[-1])
+
+        for t in targets:
+            t = t.strip("<>()")
+            if t in addr_to_idx:
+                edges.append((i, addr_to_idx[t]))
+
+    features: List[List[float]] = []
+    for instr in nodes:
+        parts = instr.split(maxsplit=1)
+        op = parts[0].lower() if parts else ""
+        operand = parts[1] if len(parts) > 1 else ""
+        api_hash = hash(operand) % 1000 if op.startswith("call") else 0
+        string_flag = int('"' in operand or "'" in operand)
+        const_flag = int(bool(re.search(r"0x[0-9a-fA-F]+|\b\d+\b", operand)))
+        features.append(
+            [
+                hash(op) % 1000,
+                hash(operand) % 1000,
+                api_hash,
+                float(string_flag),
+                float(const_flag),
+            ]
+        )
+
+    x = torch.tensor(features, dtype=torch.float)
     edge_index = (
         torch.tensor(edges, dtype=torch.long).t().contiguous()
         if edges


### PR DESCRIPTION
## Summary
- strip both `#` and `//` style comments when parsing assembly
- parse more branch/call opcodes when creating CFG edges
- enrich node features with opcode and operand hashes plus flags for API calls and constants

## Testing
- `pytest -q`
- `ruff check src/preprocess/graphify.py --fix`
- `black src/preprocess/graphify.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6840621eb20c832e81e7f0a15ae462ee